### PR TITLE
custom destination tag for dtools push

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Example usage:
         with:
           dtools-token: ${{ secrets.DTOOLS_TOKEN }}
           image: "framework/oma"
-          destination-tag: my-custom-tag # option, by default GitHub ref name
+          destination-tag: my-custom-tag # optional, by default GitHub ref name
 
 ...
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Example usage:
         with:
           dtools-token: ${{ secrets.DTOOLS_TOKEN }}
           image: "framework/oma"
+          destination-tag: my-custom-tag # option, by default GitHub ref name
 
 ...
 ```

--- a/dtools/push/action.yaml
+++ b/dtools/push/action.yaml
@@ -7,6 +7,10 @@ inputs:
   image:
     required: true
     description: Image, that should be pushed to the registry
+  destination-tag:
+    required: false
+    default: ${{ github.ref_name }}
+    description: Push image to registry with given tag
 runs:
   using: "composite"
   steps:
@@ -16,4 +20,4 @@ runs:
       env:
         PP_DTOOLS_TOKEN: ${{ inputs.dtools-token }}
       run: |
-        dtools dcr push --image ${{ inputs.image }} --dest-tag ${{ github.ref_name }} --acr-only
+        dtools dcr push --image ${{ inputs.image }} --dest-tag ${{ inputs.destination-tag }} --acr-only

--- a/dtools/push/action.yaml
+++ b/dtools/push/action.yaml
@@ -10,7 +10,7 @@ inputs:
   destination-tag:
     required: false
     default: ${{ github.ref_name }}
-    description: Push image to registry with given tag
+    description: Image tag, that should be pushed to the registry
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
We use often `tmp-sha` images instead of `github.ref_name` (which is the branch name in most cases). Let's allow to configure it!