### PR TITLE
PPNA-666 less verbose black linter

### DIFF
--- a/python/lint/action.yaml
+++ b/python/lint/action.yaml
@@ -34,7 +34,7 @@ runs:
       if: ${{ inputs.use-black == 'true' }}
       uses: psf/black@ae2c0758c9e61a385df9700dc9c231bf54887041
       with:
-        options: --check --verbose --config ${{ github.action_path }}/pyproject.toml
+        options: --check --config ${{ github.action_path }}/pyproject.toml
         src: "."
     - name: Run flake8 linter
       if: ${{ inputs.use-flake == 'true' }}


### PR DESCRIPTION
I don't want shitload of
```
reporting/__init__.py already well formatted, good job.
reporting/analytics/__init__.py already well formatted, good job.
reporting/analytics/admin.py already well formatted, good job.
reporting/analytics/apps.py already well formatted, good job.
reporting/analytics/events.py already well formatted, good job.
reporting/analytics/management/commands/__init__.py already well formatted, good job.
reporting/analytics/exceptions.py already well formatted, good job.
```
I know I did the good job..

I just want to know that
```
would reformat reporting/scheduler/test/conftest.py
```