### PR TITLE
lock python-kacl to 0.2.30

### DIFF
--- a/changelog/verify/action.yaml
+++ b/changelog/verify/action.yaml
@@ -5,4 +5,4 @@ runs:
   steps:
     - name: Verify Keep a changelog format
       shell: bash
-      run: pip install python-kacl && kacl-cli verify
+      run: pip install python-kacl==0.2.30 && kacl-cli verify


### PR DESCRIPTION
The latest release of python-kacl isn't a great success. Temporarily, we'll lock to the previous one