### PR TITLE
Python linter update

### DIFF
--- a/python/lint/action.yaml
+++ b/python/lint/action.yaml
@@ -26,18 +26,18 @@ runs:
         python-version: ${{ inputs.python-version }}
     - name: Run isort linter
       if: ${{ inputs.use-isort == 'true' }}
-      uses: jamescurtin/isort-action@f555d1d11ca0529654eb6d1f017f9e4a269ffa7f
+      uses: jamescurtin/isort-action@f14e57e1d457956c45a19c05a89cccdf087846e5 # 1.1.0
       with:
         configuration: --check-only --diff --settings-path ${{ github.action_path }}/.isort.cfg
-        requirementsFiles: ${{ inputs.requirements_files }} 
+        requirementsFiles: ${{ inputs.requirements_files }}
     - name: Run Black linter
       if: ${{ inputs.use-black == 'true' }}
-      uses: psf/black@ae2c0758c9e61a385df9700dc9c231bf54887041
+      uses: psf/black@b0d1fba7ac3be53c71fb0d3211d911e629f8aecb # 23.1.0
       with:
         options: --check --config ${{ github.action_path }}/pyproject.toml
         src: "."
     - name: Run flake8 linter
       if: ${{ inputs.use-flake == 'true' }}
-      uses: py-actions/flake8@6b71483a8fe60d4cb967d3aa4ee56e5e52711d30
+      uses: py-actions/flake8@2014ef764424fd7699d615323c17836092bec9b9 # 2.2.1
       with:
         args: "--config ${{ github.action_path }}/flake8.ini"

--- a/python/lint/flake8.ini
+++ b/python/lint/flake8.ini
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 100
+max-line-length = 120
 max-complexity = 10
 exclude = *build*,*artifacts*
 ignore = D100,D101,D102,D103,D104,D105,D106,D107,D203,D213,E203,W503,W504

--- a/python/lint/pyproject.toml
+++ b/python/lint/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-line-length = 100
+line-length = 120


### PR DESCRIPTION
As an attempt to make those linter rules appliable to more than one team:
#### line length raised to 120, to be compatible with team middleware limit
Raising that limit is way more compatible then reformatting repositories against new rules and loosing git history - 120 is still ok imho.
#### dependencies update
That's my biggest concern right now - as we should keep our `requirements/poetry/pipenv` up-to-date it's a natural thing that we should do the same with linter actions to avoid situations where github action is using older linter than repository. Rules (for black at least) happens to change from version to version so this could lead to potential problems on development.

Without single point of configuration for those tools or autocommiting through gha we will have issues with this current setup.

I'm curious about your opinion on that topic. 

Promil team can rest at ease with this one. 