### PR TITLE
HOTFIX-1 bump golangci-lint to 1.52.2

### DIFF
--- a/go/lint/action.yaml
+++ b/go/lint/action.yaml
@@ -9,7 +9,7 @@ inputs:
   golangci-lint-version:
     required: false
     description: Version of golangci-lint
-    default: "v1.48.0"
+    default: "v1.52.2"
   golangci-lint-concurrency:
     required: false
     description: Concurrency for golangci-lint


### PR DESCRIPTION
golangci-lint had an OOM when running on golang 1.20, this was fixed in new versions