### PR TITLE
INT-0 bump golint

### DIFF
--- a/go/lint/action.yaml
+++ b/go/lint/action.yaml
@@ -9,7 +9,7 @@ inputs:
   golangci-lint-version:
     required: false
     description: Version of golangci-lint
-    default: "v1.52.2"
+    default: "v1.53.2"
   golangci-lint-concurrency:
     required: false
     description: Concurrency for golangci-lint


### PR DESCRIPTION
Use newer golint that uses gosec who gets rid of
rule G307 which checks when an error is not handled when a file or socket connection is closed

Related issue:
https://github.com/securego/gosec/issues/925