### PR TITLE
INT-0 disable depguard

### DIFF
--- a/go/lint/.golangci.yml
+++ b/go/lint/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - revive
     - ifshort
     - staticcheck
-    - depguard
     - gosec
     - dogsled
     - godox


### PR DESCRIPTION
After golint update, depguards throws a lot errors `depguard XXX is not allowed from list 'Main'`

Untill we find what is going on and fix it we decided to temporarily disable it