### PR TITLE
DEVOPS-6972 python 3.12 setuptools fix

### DIFF
--- a/go/setup/integration/action.yaml
+++ b/go/setup/integration/action.yaml
@@ -18,6 +18,10 @@ runs:
       with:
         python-version: "3.x"
 
+    - name: Install setuptools
+      shell: bash
+      run: pip install setuptools
+
     - name: Install packages required for tests
       shell: bash
       run: cd ${{ inputs.test-directory }} && python setup.py develop


### PR DESCRIPTION
Python 3.12 has no longer `setuptools` [preinstalled](https://docs.python.org/3/whatsnew/3.12.html) which causes the next step to fail

https://github.com/PiwikPRO/Deployment-agent/actions/runs/6669591459/job/18127698177?pr=72
