### PR TITLE
freeze godtools version to be able to test out new releases

### DIFF
--- a/godtools/setup/action.yaml
+++ b/godtools/setup/action.yaml
@@ -22,6 +22,7 @@ runs:
         repo: 'PiwikPRO/godtools'
         file: 'godtools'
         token: ${{ steps.get-token.outputs.token }}
+        version: 'tags/0.0.11'
     - name: Setup godtools
       shell: bash
       run: chmod +x godtools && sudo mv -f godtools /usr/bin/godtools && godtools --version


### PR DESCRIPTION
Currently, godtools setup action is taking the `latest` release so we're not able to test out new features - without putting CI environments at risk if something goes wrong. 

This PR sets the fixed current version of godtools.

