### PR TITLE
Fix handling `source: docs/*.md` pattern

### DIFF
--- a/techdocs/script/config.py
+++ b/techdocs/script/config.py
@@ -174,6 +174,9 @@ class SourceFileMustExist(ConfigValidator):
         self.filesystem = filesystem
 
     def validate(self, config):
+        if nodes.looks_wildcardish(config["source"]):
+            # This validator is not applicable to wildcardish paths
+            return
         if nodes.looks_fileish(config["source"]) and not self.filesystem.is_file(
             path.join(self.from_path, config["source"])
         ):
@@ -184,7 +187,8 @@ class IfSourceIsDirectoryThenDestinationMustAlsoBeDirectory(ConfigValidator):
     def validate(self, config):
         if nodes.looks_dirish(config["source"]) and not nodes.looks_dirish(config["destination"]):
             raise ConfigError(
-                f"Source is a directory but destination is not. Did you forget to add a trailing slash to desination? Offending config: {config}"
+                f"Source is a directory but destination is not. Did you forget to add a trailing slash to desination? "
+                f"Offending config: {config}"
             )
 
 
@@ -192,7 +196,8 @@ class WildardsInTheMiddleAreApplicableOnlyToDirectories(ConfigValidator):
     def validate(self, config):
         if "*" in config["source"][:-1] and not nodes.looks_dirish(config["destination"]):
             raise ConfigError(
-                f"Putting wildcards in the middle of the pattern is only supported if the destination is a directory. Offending config: {config}"
+                f"Putting wildcards in the middle of the pattern is only supported if the destination is a directory. "
+                f"Offending config: {config}"
             )
 
 

--- a/techdocs/script/nodes.py
+++ b/techdocs/script/nodes.py
@@ -8,3 +8,7 @@ def looks_fileish(fspath):
 
 def looks_dirish(fspath):
     return fspath.endswith("/") or fspath.endswith("*") or fspath == "."
+
+
+def looks_wildcardish(fspath):
+    return "*" in fspath

--- a/techdocs/script/test_config.py
+++ b/techdocs/script/test_config.py
@@ -49,6 +49,30 @@ from filesystem import MockFilesystem
                 "documents": [
                     {
                         "project": "promil",
+                        "source": "*.md",
+                        "destination": "docs/promil/",
+                    }
+                ],
+            },
+            True,  # Wildcard for file extension
+        ),
+        (
+            {
+                "documents": [
+                    {
+                        "project": "promil",
+                        "source": "*.md",
+                        "destination": "docs/promil/test.md",
+                    }
+                ],
+            },
+            False,  # Wildcard for file extension pointing single file
+        ),
+        (
+            {
+                "documents": [
+                    {
+                        "project": "promil",
                         "source": "README.md",
                         "destination": "bla.md",
                     },

--- a/techdocs/script/test_copier.py
+++ b/techdocs/script/test_copier.py
@@ -24,9 +24,14 @@ def filesystem():
                             "source": "docs/*",
                             "destination": "somedir/",
                             "exclude": [
-                                "docs/internal/*"
-                                "docs/*.txt"
+                                "docs/internal/*",
+                                "docs/*.txt",
                             ],
+                        },
+                        {
+                            "project": "promil",
+                            "source": "other/*.txt",
+                            "destination": "somedir/",
                         },
                     ],
                 }
@@ -38,6 +43,10 @@ def filesystem():
             "/tmp/foo/docs/inner/other-dir/foo.md": "blabla",
             "/tmp/foo/docs/two.md": "blabla",
             "/tmp/foo/docs/internal/int.md": "blabla",
+            "/tmp/foo/other/uno.txt": "blabla",
+            "/tmp/foo/other/due.txt": "blabla",
+            "/tmp/foo/other/non-text.md": "blabla",
+            "/tmp/foo/other/level/due.txt": "blabla",
             "/tmp/bar/projects.json": json.dumps({"promil": {"path": "docs/promil"}}),
         }
     )
@@ -63,3 +72,7 @@ def test_copier(filesystem):
     assert filesystem.is_file("/tmp/bar/docs/promil/somedir/inner/other-dir/foo.md")
     assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/first.txt")
     assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/second.txt")
+    assert filesystem.is_file("/tmp/bar/docs/promil/somedir/uno.txt")
+    assert filesystem.is_file("/tmp/bar/docs/promil/somedir/due.txt")
+    assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/non-text.md")
+    assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/level/due.txt")

--- a/techdocs/script/test_copier.py
+++ b/techdocs/script/test_copier.py
@@ -23,13 +23,18 @@ def filesystem():
                             "project": "promil",
                             "source": "docs/*",
                             "destination": "somedir/",
-                            "exclude": ["docs/internal/*"],
+                            "exclude": [
+                                "docs/internal/*"
+                                "docs/*.txt"
+                            ],
                         },
                     ],
                 }
             ),
             "/tmp/foo/README.md": "blabla",
             "/tmp/foo/docs/one.md": "blabla",
+            "/tmp/foo/docs/first.txt": "blabla",
+            "/tmp/foo/docs/second.txt": "blabla",
             "/tmp/foo/docs/inner/other-dir/foo.md": "blabla",
             "/tmp/foo/docs/two.md": "blabla",
             "/tmp/foo/docs/internal/int.md": "blabla",
@@ -56,3 +61,5 @@ def test_copier(filesystem):
     assert filesystem.is_file("/tmp/bar/docs/promil/somedir/one.md")
     assert filesystem.is_file("/tmp/bar/docs/promil/somedir/two.md")
     assert filesystem.is_file("/tmp/bar/docs/promil/somedir/inner/other-dir/foo.md")
+    assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/first.txt")
+    assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/second.txt")


### PR DESCRIPTION
In current solution such configuration:
```
source: docs/*.md
```
Would cause an error that `Source file `docs/*.md` does not exist` - obviously, this isn't a pointer to a single file but a wildcard suggesting that we're looking for set of files. 

Additional check for "wildcardishness" for `SourceFileMustExist` validator should do the trick. I've added some test cases as a proof.