### PR TITLE
ARCH-256 copier action branch switch

### DIFF
--- a/.github/workflows/push_docs.yaml
+++ b/.github/workflows/push_docs.yaml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Run Copy Script in Dry Run Mode
         id: dry-run
-        uses: PiwikPRO/actions/techdocs@arch-256-update-pr-description-with-details
+        uses: PiwikPRO/actions/techdocs@master
         with:
           from: .
           to: Tech-docs


### PR DESCRIPTION
Fixes missing branch switch from https://github.com/PiwikPRO/actions/pull/68 