### PR TITLE
ARCH-275 Aggregation of PlantUML diagrams

### DIFF
--- a/techdocs/script/detectors.py
+++ b/techdocs/script/detectors.py
@@ -1,0 +1,169 @@
+import copy
+import re
+from os import path
+
+import nodes
+from config import Config, ProjectDetailsReader
+from index import FileIndex, FileIndexItem
+from operations import (
+    CopyOperation,
+    DeleteOperation,
+    DockerPlantUMLGenerator,
+    PlantUMLDiagramRenderOperation,
+)
+
+
+class CopyDetector:
+    def __init__(self, from_path: str, to_path: str, config: Config) -> None:
+        self.copy_rules = [
+            Rule(
+                document_rule,
+                DefaultMatcher(document_rule.source),
+                [DefaultMatcher(excluded) for excluded in document_rule.exclude],
+            )
+            for document_rule in config.documents
+        ]
+        self.from_path = from_path
+        self.to_path = to_path
+
+    def detect(self, fs, previous_operations):
+        return [
+            self._for_file(fs, file)
+            for file in fs.scan(self.from_path, ".*")
+            if self._for_file(fs, file) is not None
+        ]
+
+    def _for_file(self, fs, path: str):
+        for rule in self.copy_rules:
+            if rule.match(path):
+                return self._create_operation(fs, path, rule)
+        return None
+
+    def _create_operation(self, fs, file, rule):
+        if nodes.looks_fileish(rule.config.source) and nodes.looks_dirish(rule.config.destination):
+            relative_src, relative_dst = (
+                file,
+                path.join(rule.config.destination, path.basename(file)),
+            )
+        elif nodes.looks_fileish(rule.config.source) and nodes.looks_fileish(
+            rule.config.destination
+        ):
+            relative_src, relative_dst = (
+                file,
+                rule.config.destination,
+            )
+        elif nodes.looks_dirish(rule.config.source) and nodes.looks_dirish(rule.config.destination):
+            relative_src, relative_dst = (
+                file,
+                path.join(rule.config.destination, file[len(rule.config.source) - 1 :]),
+            )
+        else:
+            return None
+        return CopyOperation(
+            source_abs=path.abspath(path.join(self.from_path, relative_src)),
+            destination_abs=path.abspath(
+                path.join(
+                    self.to_path,
+                    ProjectDetailsReader(self.to_path, fs).doc_path(rule.config.project),
+                    relative_dst,
+                ),
+            ),
+        )
+
+
+class DefaultMatcher:
+    def __init__(self, str_to_match):
+        self.regex = re.escape(str_to_match).replace("\\*", ".*")
+
+    def match(self, path):
+        return re.match(self.regex, path) is not None
+
+
+class Rule:
+    def __init__(self, document_config_rule, matcher, excluders) -> None:
+        self.config = document_config_rule
+        self.matcher = matcher
+        self.excluders = excluders
+
+    def match(self, file):
+        return self.matcher.match(file) and not (
+            any([excluder.match(file) for excluder in self.excluders])
+        )
+
+
+class DeleteDetector:
+    def __init__(self, repo, index, from_path, to_path) -> None:
+        self.repo = repo
+        self.index = index
+        self.from_path = from_path
+        self.to_path = to_path
+
+    def detect(self, fs, previous_operations):
+        child_result = previous_operations
+        child_result_files_to_be_copied = [
+            path.relpath(j, self.to_path)
+            for sub in [o.destination_files() for o in child_result]
+            for j in sub
+        ]
+        indexed_items = list([i for i in self.index.items if i.repo == self.repo])
+        for item in indexed_items:
+            if item.file not in child_result_files_to_be_copied:
+                child_result.append(
+                    DeleteOperation(
+                        path.abspath(
+                            path.join(self.to_path, item.file),
+                        )
+                    )
+                )
+                self.index.remove(item)
+
+        for item in child_result_files_to_be_copied:
+            self.index.add(FileIndexItem(item, self.repo))
+        return child_result
+
+
+class UnnecessaryOperationsFilteringDetector:
+    def detect(self, fs, previous_operations):
+        return list(filter(lambda op: op.has_changes(fs), previous_operations))
+
+
+class PlantUMLDiagramsDetector:
+    def __init__(self, generator=None):
+        self.generator = generator or DockerPlantUMLGenerator()
+
+    def detect(self, fs, previous_operations):
+        pumls = list(
+            filter(
+                lambda op: any([f.endswith(".puml") for f in op.source_files()]),
+                previous_operations,
+            )
+        )
+        return list(
+            filter(
+                lambda op: not any([f.endswith(".puml") for f in op.source_files()]),
+                previous_operations,
+            )
+        ) + [
+            PlantUMLDiagramRenderOperation(
+                puml.source_abs,
+                swap_extension(puml.destination_abs, "svg"),
+                self.generator,
+            )
+            for puml in pumls
+        ]
+
+
+def swap_extension(file_path: str, new_extension: str) -> str:
+    base_name = path.splitext(file_path)[0]
+    return f"{base_name}.{new_extension}"
+
+
+class OperationDetectorChain:
+    def __init__(self, *detectors):
+        self.detectors = detectors
+
+    def operations(self, fs):
+        operations = []
+        for detector in self.detectors:
+            operations = detector.detect(fs, copy.deepcopy(operations))
+        return operations

--- a/techdocs/script/index.py
+++ b/techdocs/script/index.py
@@ -1,0 +1,75 @@
+import json
+from contextlib import contextmanager
+from dataclasses import dataclass
+from hashlib import sha256
+from os import path
+
+
+class FileIndex:
+    def __init__(self, items: tuple):
+        self.items = items
+        self.removed = ()
+
+    def add(self, item):
+        for existing_item in self.items:
+            # If it's not the same file, keep looking
+            if item.file != existing_item.file:
+                continue
+            # If it's the same file coming from the same repo, do nothing, just return
+            if item.repo == existing_item.repo:
+                return
+            # If it's the same file coming from a different repo, raise an error
+            raise FileIndexError(
+                f"The file {item.file} is already indexed from repository {existing_item.repo}"
+            )
+        # If the loop ends, it means the file is not indexed yet, so add it
+        self.items = self.items + (item,)
+
+    def remove(self, item):
+        removed = tuple(filter(lambda existing_item: existing_item.file == item.file, self.items))
+        self.items = tuple(
+            filter(lambda existing_item: existing_item.file != item.file, self.items)
+        )
+        self.removed = self.removed + removed
+
+
+@dataclass
+class FileIndexItem:
+    file: str
+    repo: str
+
+
+class FileIndexLoader:
+    @classmethod
+    def load(cls, fspath, fs):
+        items = []
+        for file in fs.scan(fspath, ".*"):
+            cnt = json.loads(fs.read_string(path.join(fspath, file)))
+            items.append(FileIndexItem(cnt["file"], cnt["repo"]))
+        return FileIndex(tuple(items))
+
+    @classmethod
+    def save(cls, index, fspath, fs):
+        for item in index.items:
+            fs.write_string(
+                path.join(fspath, item.repo, hash(item.file)),
+                json.dumps({"file": item.file, "repo": item.repo}),
+            )
+        for removed in index.removed:
+            fs.delete(path.join(fspath, removed.repo, hash(removed.file)))
+
+    @classmethod
+    @contextmanager
+    def loaded(cls, fspath, fs, save=True):
+        index = cls.load(fspath, fs)
+        yield index
+        if save:
+            cls.save(index, fspath, fs)
+
+
+class FileIndexError(Exception):
+    pass
+
+
+def hash(some_str):
+    return sha256(some_str.encode()).hexdigest()

--- a/techdocs/script/operations.py
+++ b/techdocs/script/operations.py
@@ -1,234 +1,138 @@
-import json
-import re
-from contextlib import contextmanager
-from dataclasses import dataclass
+import os
+import shutil
+import subprocess
+import tempfile
 from hashlib import sha256
-from os import path
-
-import nodes
-from config import Config, ProjectDetailsReader
 
 
-@dataclass
-class FilesystemOperation:
-    TYPE_COPY = "copy"
-    TYPE_DELETE = "delete"
+class CopyOperation:
+    def __init__(self, source_abs, destination_abs):
+        self.source_abs = source_abs
+        self.destination_abs = destination_abs
 
-    type: str
-    source_abs: str
-    destination_abs: str
+    def name(self):
+        return "copy"
 
-    def __str__(self):
-        if self.type == FilesystemOperation.TYPE_COPY:
-            return "Copy file {} to {}".format(self.source_abs, self.destination_abs)
-        elif self.type == FilesystemOperation.TYPE_DELETE:
-            return "Delete file {}".format(self.destination_abs)
-        else:
-            return "Unknown operation"
+    def execute(self, fs):
+        fs.copy(self.source_abs, self.destination_abs)
 
-
-class CopyDetector:
-    def __init__(self, from_path: str, to_path: str, config: Config) -> None:
-        self.copy_rules = [
-            Rule(
-                document_rule,
-                DefaultMatcher(document_rule.source),
-                [DefaultMatcher(excluded) for excluded in document_rule.exclude],
-            )
-            for document_rule in config.documents
-        ]
-        self.from_path = from_path
-        self.to_path = to_path
-
-    def detect(self, filesystem):
-        return [
-            self._for_file(filesystem, file)
-            for file in filesystem.scan(self.from_path, ".*")
-            if self._for_file(filesystem, file) is not None
-        ]
-
-    def _for_file(self, filesystem, path: str):
-        for rule in self.copy_rules:
-            if rule.match(path):
-                return self._create_operation(filesystem, path, rule)
-        return None
-
-    def _create_operation(self, filesystem, file, rule):
-        if nodes.looks_fileish(rule.config.source) and nodes.looks_dirish(rule.config.destination):
-            relative_src, relative_dst = (
-                file,
-                path.join(rule.config.destination, path.basename(file)),
-            )
-        elif nodes.looks_fileish(rule.config.source) and nodes.looks_fileish(
-            rule.config.destination
+    def has_changes(self, fs):
+        if (not fs.is_file(self.destination_abs)) or hashb(fs.read_bytes(self.source_abs)) != hashb(
+            fs.read_bytes(self.destination_abs)
         ):
-            relative_src, relative_dst = (
-                file,
-                rule.config.destination,
-            )
-        elif nodes.looks_dirish(rule.config.source) and nodes.looks_dirish(rule.config.destination):
-            relative_src, relative_dst = (
-                file,
-                path.join(rule.config.destination, file[len(rule.config.source) - 1 :]),
-            )
-        else:
-            return None
-        return FilesystemOperation(
-            type=FilesystemOperation.TYPE_COPY,
-            source_abs=path.abspath(path.join(self.from_path, relative_src)),
-            destination_abs=path.abspath(
-                path.join(
-                    self.to_path,
-                    ProjectDetailsReader(self.to_path, filesystem).doc_path(rule.config.project),
-                    relative_dst,
-                ),
+            return True
+        return False
+
+    def source_files(self):
+        return [self.source_abs]
+
+    def destination_files(self):
+        return [self.destination_abs]
+
+    def mkd(self, path_formatter):
+        return f"* [COPY] {path_formatter.format(self.source_abs)} -> {path_formatter.format(self.destination_abs)}"
+
+
+class DeleteOperation:
+    def __init__(self, destination_abs):
+        self.destination_abs = destination_abs
+
+    def name(self):
+        return "delete"
+
+    def execute(self, fs):
+        fs.delete(self.destination_abs)
+
+    def source_files(self):
+        return []
+
+    def destination_files(self):
+        return []
+
+    def has_changes(self, fs):
+        return True
+
+    def mkd(self, path_formatter):
+        return f"* [DELETE] {path_formatter.format(self.destination_abs)}"
+
+
+class PlantUMLDiagramRenderOperation:
+    def __init__(self, source_puml_abs, destination_svg_abs, generator):
+        self.source_puml_abs = source_puml_abs
+        self.destination_svg_abs = destination_svg_abs
+        self.generator = generator
+
+    def name(self):
+        return "plantuml"
+
+    def execute(self, fs):
+        fs.write_string(
+            self.destination_svg_abs,
+            self.generator.generate(fs, self.source_puml_abs).replace(
+                "<svg ", self.header(fs) + "<svg "
             ),
         )
 
+    def source_files(self):
+        return [self.source_puml_abs]
 
-class DeleteDetector:
-    def __init__(self, repo, index, from_path, to_path, child) -> None:
-        self.repo = repo
-        self.index = index
-        self.from_path = from_path
-        self.to_path = to_path
-        self.child = child
+    def destination_files(self):
+        return [self.destination_svg_abs]
 
-    def detect(self, filesystem):
-        child_result = self.child.detect(filesystem)
-        child_result_files_to_be_copied = [
-            path.relpath(op.destination_abs, self.to_path)
-            for op in child_result
-            if op.type == FilesystemOperation.TYPE_COPY
-        ]
-        indexed_items = list([i for i in self.index.items if i.repo == self.repo])
-        for item in indexed_items:
-            if item.file not in child_result_files_to_be_copied:
-                child_result.append(
-                    FilesystemOperation(
-                        type=FilesystemOperation.TYPE_DELETE,
-                        source_abs=None,
-                        destination_abs=path.abspath(
-                            path.join(self.to_path, item.file),
-                        ),
-                    )
-                )
-                self.index.remove(item)
+    def has_changes(self, fs):
+        if not fs.is_file(self.destination_svg_abs):
+            return True
+        return self.header(fs) not in fs.read_string(self.destination_svg_abs)
 
-        for item in child_result_files_to_be_copied:
-            self.index.add(FileIndexItem(item, self.repo))
-        return child_result
+    def header(self, fs):
+        return header(hashb(get_full_puml_content(fs, self.source_puml_abs)))
+
+    def mkd(self, path_formatter):
+        return f"* [PLANTUML] {path_formatter.format(self.source_puml_abs)} -> {path_formatter.format(self.destination_svg_abs)}"
 
 
-def hash(some_str):
-    return sha256(some_str.encode()).hexdigest()
+def header(hash):
+    return "<!-- @tech-docs-hash=" + hash + " -->"
 
 
 def hashb(data):
     return sha256(data).hexdigest()
 
 
-class UnnecessaryOperationsFilteringDetector:
-    def __init__(self, child) -> None:
-        self.child = child
-
-    def detect(self, filesystem):
-        return list(filter(self.requires_changes_on_fs(filesystem), self.child.detect(filesystem)))
-
-    def requires_changes_on_fs(self, filesystem):
-        def inner(operation):
-            if operation.type == operation.TYPE_DELETE:
-                return True
-            if (not filesystem.is_file(operation.destination_abs)) or hashb(
-                filesystem.read_bytes(operation.source_abs)
-            ) != hashb(filesystem.read_bytes(operation.destination_abs)):
-                return True
-            return False
-
-        return inner
-
-
-class FileIndex:
-    def __init__(self, items: tuple):
-        self.items = items
-        self.removed = ()
-
-    def add(self, item):
-        for existing_item in self.items:
-            # If it's not the same file, keep looking
-            if item.file != existing_item.file:
-                continue
-            # If it's the same file coming from the same repo, do nothing, just return
-            if item.repo == existing_item.repo:
-                return
-            # If it's the same file coming from a different repo, raise an error
-            raise FileIndexError(
-                f"The file {item.file} is already indexed from repository {existing_item.repo}"
+def get_full_puml_content(fs, the_path):
+    content = fs.read_bytes(the_path)
+    lines = content.split(b"\n")
+    for i, line in enumerate(lines):
+        if line.startswith(b"!include ") and b"http://" not in line and b"https://" not in line:
+            lines[i] = get_full_puml_content(
+                fs, os.path.join(os.path.dirname(the_path), line.split(b"!include ")[1].decode())
             )
-        # If the loop ends, it means the file is not indexed yet, so add it
-        self.items = self.items + (item,)
-
-    def remove(self, item):
-        removed = tuple(filter(lambda existing_item: existing_item.file == item.file, self.items))
-        self.items = tuple(
-            filter(lambda existing_item: existing_item.file != item.file, self.items)
-        )
-        self.removed = self.removed + removed
+    return b"\n".join(lines)
 
 
-@dataclass
-class FileIndexItem:
-    file: str
-    repo: str
-
-
-class FileIndexLoader:
-    @classmethod
-    def load(cls, fspath, filesystem):
-        items = []
-        for file in filesystem.scan(fspath, ".*"):
-            cnt = json.loads(filesystem.read_string(path.join(fspath, file)))
-            items.append(FileIndexItem(cnt["file"], cnt["repo"]))
-        return FileIndex(tuple(items))
-
-    @classmethod
-    def save(cls, index, fspath, filesystem):
-        for item in index.items:
-            filesystem.write_string(
-                path.join(fspath, item.repo, hash(item.file)),
-                json.dumps({"file": item.file, "repo": item.repo}),
+class DockerPlantUMLGenerator:
+    def generate(self, fs, source_puml_abs):
+        try:
+            dirpath = tempfile.mkdtemp()
+            subprocess.run(
+                [
+                    "docker",
+                    "run",
+                    "-v",
+                    f"{os.path.dirname(source_puml_abs)}:/src",
+                    "-v",
+                    f"{dirpath}:/out",
+                    "ghcr.io/plantuml/plantuml:1",
+                    f"/src/{os.path.basename(source_puml_abs)}",
+                    "-o",
+                    "/out",
+                    "-tsvg",
+                ]
             )
-        for removed in index.removed:
-            filesystem.delete(path.join(fspath, removed.repo, hash(removed.file)))
-
-    @classmethod
-    @contextmanager
-    def loaded(cls, fspath, filesystem, save=True):
-        index = cls.load(fspath, filesystem)
-        yield index
-        if save:
-            cls.save(index, fspath, filesystem)
-
-
-class FileIndexError(Exception):
-    pass
-
-
-class DefaultMatcher:
-    def __init__(self, str_to_match):
-        self.regex = re.escape(str_to_match).replace("\\*", ".*")
-
-    def match(self, path):
-        return re.match(self.regex, path) is not None
-
-
-class Rule:
-    def __init__(self, document_config_rule, matcher, excluders) -> None:
-        self.config = document_config_rule
-        self.matcher = matcher
-        self.excluders = excluders
-
-    def match(self, file):
-        return self.matcher.match(file) and not (
-            any([excluder.match(file) for excluder in self.excluders])
-        )
+            generated_files = fs.scan(dirpath, ".*")
+            if len(generated_files) != 1:
+                raise Exception("PlantUML generation failed")
+            with open(os.path.join(dirpath, generated_files[0]), "r") as f:
+                return f.read()
+        finally:
+            shutil.rmtree(dirpath)

--- a/techdocs/script/test_cli_integration.py
+++ b/techdocs/script/test_cli_integration.py
@@ -1,0 +1,66 @@
+import json
+import os
+import subprocess
+
+import pytest
+from filesystem import Filesystem
+
+
+def prepare_fs(files):
+    fs = Filesystem()
+    for file in files:
+        fs.write_string(file, files[file])
+
+
+def test_integration(tmp_path):
+    prepare_fs(
+        {
+            os.path.join(tmp_path, k): v
+            for k, v in {
+                "src/README.md": "readme",
+                "src/docs/one.md": "one",
+                "src/docs/two.txt": "two",
+                "dst/projects.json": json.dumps({"promil": {"path": "docs/promil"}}),
+                "config.json": json.dumps(
+                    {
+                        "documents": [
+                            {
+                                "project": "promil",
+                                "source": "README.md",
+                                "destination": "bla.md",
+                            },
+                            {
+                                "project": "promil",
+                                "source": "docs/*",
+                                "destination": "somedir/",
+                                "exclude": [
+                                    "docs/*.txt",
+                                ],
+                            },
+                        ],
+                    }
+                ),
+            }.items()
+        }
+    )
+    assert (
+        subprocess.run(
+            [
+                "python",
+                "cli.py",
+                "copy",
+                "--from",
+                os.path.join(tmp_path, "src"),
+                "--to",
+                os.path.join(tmp_path, "dst"),
+                "--config",
+                os.path.join(tmp_path, "config.json"),
+                "--index",
+                "promil",
+            ]
+        ).returncode
+        == 0
+    )
+    assert os.path.exists(os.path.join(tmp_path, "dst/docs/promil/bla.md"))
+    assert os.path.exists(os.path.join(tmp_path, "dst/docs/promil/somedir/one.md"))
+    assert not os.path.exists(os.path.join(tmp_path, "dst/docs/promil/somedir/two.txt"))

--- a/techdocs/script/test_copier.py
+++ b/techdocs/script/test_copier.py
@@ -3,8 +3,8 @@ import json
 import pytest
 from config import ConfigLoader
 from copier import Copier
+from detectors import CopyDetector, OperationDetectorChain
 from filesystem import MockFilesystem
-from operations import CopyDetector
 
 
 @pytest.fixture
@@ -54,13 +54,15 @@ def filesystem():
 
 def test_copier(filesystem):
     copier = Copier(
-        CopyDetector(
-            "/tmp/foo",
-            "/tmp/bar",
-            ConfigLoader.default("/tmp/foo", "/tmp/bar", filesystem).load(
-                "/tmp/techdocs/config.json"
-            ),
-        ),
+        OperationDetectorChain(
+            CopyDetector(
+                "/tmp/foo",
+                "/tmp/bar",
+                ConfigLoader.default("/tmp/foo", "/tmp/bar", filesystem).load(
+                    "/tmp/techdocs/config.json"
+                ),
+            )
+        ).operations(filesystem),
         filesystem,
     )
 


### PR DESCRIPTION
After all those refactors I added an "integration" tests that directly calls `cli.py` with subprocess, to make sure, that everything still glues together correctly.

If you'd like to test that, you need (unfortunately) to setup a local directory for synchronization yourself. If a single "plantuml" file is spotted in the copy rule it should automatically be considered a diagram and converted using docker container.

I used such config for tests, the `--from` is `Promil-docs` repo, `--to` is `Tech-docs` repo:
```json
{
  "documents":  [
      {
         "source": "docs/internal/diagrams/src/azure/systemContext.puml", 
         "destination": "diagrams/azure.svg", 
         "project": "promil"
      }
    ]
 }

```

How it looks:
```sh
$ python cli.py copy --from ~/Projects/promil/Promil-docs --to ~/Projects/promil/Tech-docs --config /tmp/config.json --index Promil-docs
* [PLANTUML] docs/internal/diagrams/src/azure/systemContext.puml -> docs/promil/diagrams/azure.svg

```
![image](https://github.com/PiwikPRO/actions/assets/4959057/5561c876-35d4-474c-835a-3275f69c73be)
