### PR TITLE
Dont fail build if tag is not a valid semver

### DIFF
--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -34,10 +34,6 @@ inputs:
     required: false
     default: "true" # TODO: change to "false" to enable signing globally later on
     description: Don't sign pushed images.
-  sign-only-semver:
-    required: false
-    default: "true"
-    description: Sign only semver tags
 runs:
   using: "composite"
   steps:
@@ -83,11 +79,6 @@ runs:
           exit 0
         fi
         
-        if [[ "${{ inputs.sign-only-semver }}" == 'false' ]]; then
-          echo "::set-output name=should_sign::true"
-          exit 0
-        fi 
-
         TAG_NAME=${GITHUB_REF/refs\/tags\//}
         SEMVER_REGEX="^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$"
         if [[ "$TAG_NAME" =~ $SEMVER_REGEX ]]; then

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -73,25 +73,35 @@ runs:
         GODTOOLS_KEY: ${{ inputs.godtools-key }}
 
 
-    - name: Check if tag is a valid semver
-      id: semver_check
-      if: ${{ startsWith(github.ref, 'refs/tags/') && inputs.sign-only-semver == 'true' }}
+    - name: Check if tag should be signed
+      id: sign_check
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       shell: bash
       run: |
+        if [[ "${{ inputs.skip-signing }}" == 'true' ]]; then
+          echo "::set-output name=should_sign::false"
+          exit 0
+        fi
+        
+        if [[ "${{ inputs.sign-only-semver }}" == 'false' ]]; then
+          echo "::set-output name=should_sign::true"
+          exit 0
+        fi 
+
         TAG_NAME=${GITHUB_REF/refs\/tags\//}
         SEMVER_REGEX="^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$"
         if [[ "$TAG_NAME" =~ $SEMVER_REGEX ]]; then
-          echo "::set-output name=valid_semver::true"
+          echo "::set-output name=should_sign::true"
         else
-          echo "::set-output name=valid_semver::false"
+          echo "::set-output name=should_sign::false"
         fi    
 
     - name: Download image signing toolkit (cosign)
-      if: ${{ steps.semver_check.outputs.valid_semver == 'true' && inputs.skip-signing != 'true' }}
+      if: ${{ steps.sign_check.outputs.should_sign == 'true' }}
       uses: PiwikPRO/actions/cosign/download@85b53606f434c343f5b885839b188a7376d38d12
 
     - name: Sign production docker image
-      if: ${{ steps.semver_check.outputs.valid_semver == 'true' && inputs.skip-signing != 'true' }}
+      if: ${{ steps.sign_check.outputs.should_sign == 'true' }}
       shell: bash
       run: |
         godtools docker sign --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:${{ inputs.destination-tag }}

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -34,6 +34,10 @@ inputs:
     required: false
     default: "true" # TODO: change to "false" to enable signing globally later on
     description: Don't sign pushed images.
+  sign-only-semver:
+    required: false
+    default: "true"
+    description: Sign only semver tags
 runs:
   using: "composite"
   steps:
@@ -57,6 +61,7 @@ runs:
         GODTOOLS_CONFIG: ${{ inputs.godtools-config }}
         GODTOOLS_KEY: ${{ inputs.godtools-key }}
 
+
     - name: Push production docker image
       if: startsWith(github.ref, 'refs/tags')
       shell: bash
@@ -67,12 +72,26 @@ runs:
         GODTOOLS_CONFIG: ${{ inputs.godtools-config }}
         GODTOOLS_KEY: ${{ inputs.godtools-key }}
 
+
+    - name: Check if tag is a valid semver
+      id: semver_check
+      if: ${{ startsWith(github.ref, 'refs/tags/') && inputs.sign-only-semver == 'true' }}
+      shell: bash
+      run: |
+        TAG_NAME=${GITHUB_REF/refs\/tags\//}
+        SEMVER_REGEX="^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$"
+        if [[ "$TAG_NAME" =~ $SEMVER_REGEX ]]; then
+          echo "::set-output name=valid_semver::true"
+        else
+          echo "::set-output name=valid_semver::false"
+        fi    
+
     - name: Download image signing toolkit (cosign)
-      if: ${{ startsWith(github.ref, 'refs/tags') && inputs.skip-signing != 'true' }}
+      if: ${{ steps.semver_check.outputs.valid_semver == 'true' && inputs.skip-signing != 'true' }}
       uses: PiwikPRO/actions/cosign/download@85b53606f434c343f5b885839b188a7376d38d12
 
     - name: Sign production docker image
-      if: ${{ startsWith(github.ref, 'refs/tags') && inputs.skip-signing != 'true' }}
+      if: ${{ steps.semver_check.outputs.valid_semver == 'true' && inputs.skip-signing != 'true' }}
       shell: bash
       run: |
         godtools docker sign --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:${{ inputs.destination-tag }}

--- a/godtools/setup/action.yaml
+++ b/godtools/setup/action.yaml
@@ -22,7 +22,6 @@ runs:
         repo: 'PiwikPRO/godtools'
         file: 'godtools'
         token: ${{ steps.get-token.outputs.token }}
-        version: 'tags/0.0.22-removed-semver-check'
     - name: Install 1Password CLI
       uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f
     - name: Setup godtools

--- a/godtools/setup/action.yaml
+++ b/godtools/setup/action.yaml
@@ -22,6 +22,7 @@ runs:
         repo: 'PiwikPRO/godtools'
         file: 'godtools'
         token: ${{ steps.get-token.outputs.token }}
+        version: 'tags/0.0.22-removed-semver-check'
     - name: Setup godtools
       shell: bash
       run: chmod +x godtools && sudo mv -f godtools /usr/bin/godtools && godtools --version


### PR DESCRIPTION
If tag is not a semver - just skip the steps instead of failing build.

There is a `sign-only-semver` attribute to bypass that check if necessary.