### PR TITLE
ARCH-404 tag tmp images by commit AND by branch

### DIFF
--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -48,9 +48,7 @@ runs:
         IMAGE_BY_COMMIT=tmp-$(git rev-parse --short HEAD)
         IMAGE_BY_BRANCH=tmp-$(git rev-parse --abbrev-ref HEAD | tr "/" "-" | tr '[:upper:]' '[:lower:]')
         
-        [ "${{ inputs.tag-latest }}" = "true" ] && \
-        docker tag ${{ inputs.image }} ${{ inputs.image }}:$IMAGE_BY_COMMIT && \ 
-        docker tag ${{ inputs.image }} ${{ inputs.image }}:IMAGE_BY_BRANCH;
+        [ "${{ inputs.tag-latest }}" = "true" ] && docker tag ${{ inputs.image }} ${{ inputs.image }}:$IMAGE_BY_COMMIT && docker tag ${{ inputs.image }} ${{ inputs.image }}:IMAGE_BY_BRANCH;
         
         godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_COMMIT;
         godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_BRANCH;

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -42,13 +42,13 @@ runs:
   using: "composite"
   steps:
     - name: Push tmp docker images
-      if: ${{ inputs.push-tmp-image == 'true' && !startsWith(github.ref, 'refs/tags') }}
+      if: ${{ inputs.push-tmp-image == 'true' && !startsWith(github.ref, 'refs/tags') && inputs.tag-latest == 'true' }}
       shell: bash
       run: |
         IMAGE_BY_COMMIT=tmp-$(git rev-parse --short HEAD)
         IMAGE_BY_BRANCH=tmp-$(git rev-parse --abbrev-ref HEAD | tr "/" "-" | tr '[:upper:]' '[:lower:]')
         
-        [ "${{ inputs.tag-latest }}" = "true" ] && docker tag ${{ inputs.image }} ${{ inputs.image }}:$IMAGE_BY_COMMIT;
+        docker tag ${{ inputs.image }} ${{ inputs.image }}:$IMAGE_BY_COMMIT;
         docker tag ${{ inputs.image }}:$IMAGE_BY_COMMIT ${{ inputs.image }}:IMAGE_BY_BRANCH
         
         godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_COMMIT;

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -49,7 +49,7 @@ runs:
         IMAGE_BY_BRANCH=tmp-$(git rev-parse --abbrev-ref HEAD | tr "/" "-" | tr '[:upper:]' '[:lower:]')
         
         docker tag ${{ inputs.image }} ${{ inputs.image }}:$IMAGE_BY_COMMIT;
-        docker tag ${{ inputs.image }}:$IMAGE_BY_COMMIT ${{ inputs.image }}:IMAGE_BY_BRANCH;
+        docker tag ${{ inputs.image }}:$IMAGE_BY_COMMIT ${{ inputs.image }}:$IMAGE_BY_BRANCH;
         
         godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_COMMIT;
         godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_BRANCH;

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -41,12 +41,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Push tmp docker image
+    - name: Push tmp docker images
       if: ${{ inputs.push-tmp-image == 'true' && !startsWith(github.ref, 'refs/tags') }}
       shell: bash
       run: |
-        [ "${{ inputs.tag-latest }}" = "true" ] && docker tag ${{ inputs.image }} ${{ inputs.image }}:tmp-$(git rev-parse --short HEAD);
-        godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:tmp-$(git rev-parse --short HEAD)
+        IMAGE_BY_COMMIT=tmp-$(git rev-parse --short HEAD)
+        IMAGE_BY_BRANCH=tmp-$(git rev-parse --abbrev-ref HEAD | tr "/" "-" | tr '[:upper:]' '[:lower:]')
+        
+        [ "${{ inputs.tag-latest }}" = "true" ] && \
+        docker tag ${{ inputs.image }} ${{ inputs.image }}:$IMAGE_BY_COMMIT && \ 
+        docker tag ${{ inputs.image }} ${{ inputs.image }}:IMAGE_BY_BRANCH;
+        
+        godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_COMMIT;
+        godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_BRANCH;
       env:
         GODTOOLS_CONFIG: ${{ inputs.godtools-config }}
         GODTOOLS_KEY: ${{ inputs.godtools-key }}

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -49,7 +49,7 @@ runs:
         IMAGE_BY_BRANCH=tmp-$(git rev-parse --abbrev-ref HEAD | tr "/" "-" | tr '[:upper:]' '[:lower:]')
         
         docker tag ${{ inputs.image }} ${{ inputs.image }}:$IMAGE_BY_COMMIT;
-        docker tag ${{ inputs.image }}:$IMAGE_BY_COMMIT ${{ inputs.image }}:IMAGE_BY_BRANCH
+        docker tag ${{ inputs.image }}:$IMAGE_BY_COMMIT ${{ inputs.image }}:IMAGE_BY_BRANCH;
         
         godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_COMMIT;
         godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_BRANCH;

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -48,7 +48,8 @@ runs:
         IMAGE_BY_COMMIT=tmp-$(git rev-parse --short HEAD)
         IMAGE_BY_BRANCH=tmp-$(git rev-parse --abbrev-ref HEAD | tr "/" "-" | tr '[:upper:]' '[:lower:]')
         
-        [ "${{ inputs.tag-latest }}" = "true" ] && docker tag ${{ inputs.image }} ${{ inputs.image }}:$IMAGE_BY_COMMIT && docker tag ${{ inputs.image }} ${{ inputs.image }}:IMAGE_BY_BRANCH;
+        [ "${{ inputs.tag-latest }}" = "true" ] && docker tag ${{ inputs.image }} ${{ inputs.image }}:$IMAGE_BY_COMMIT;
+        docker tag ${{ inputs.image }}:$IMAGE_BY_COMMIT ${{ inputs.image }}:IMAGE_BY_BRANCH
         
         godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_COMMIT;
         godtools docker push --registry-id "${{ inputs.registries }}" ${{ inputs.image }}:$IMAGE_BY_BRANCH;


### PR DESCRIPTION
Additionally to tmp images like `tmp-49f6fb9` we will also create tmp image for given branch with some additional sanitization to meet docker tag criteria.

For this branch `feature/ARCH-404-tag-tmp-with-branch` it would be `tmp-feature-arch-404-tag-tmp-with-branch`

Those images will share the retention policy with existing ones.

That approach allows one of our teams to preserve their development habits. 