### PR TITLE
update fetch-gh-release-asset version to 1.1.2

### DIFF
--- a/godtools/setup/action.yaml
+++ b/godtools/setup/action.yaml
@@ -17,7 +17,7 @@ runs:
         private-key: ${{ inputs.reporeader-private-key }}
         app-id: ${{ inputs.reporeader-application-id }}
     - name: Download godtools
-      uses: dsaltares/fetch-gh-release-asset@3942ce82f1192754cd487a86f03eef6eeb89b5da
+      uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7
       with:
         repo: 'PiwikPRO/godtools'
         file: 'godtools'


### PR DESCRIPTION
Small update that removes deprecation warning:

> Node.js 16 actions are deprecated.