### PR TITLE
skip-invalid-documents flag

### DIFF
--- a/techdocs/script/cli.py
+++ b/techdocs/script/cli.py
@@ -7,9 +7,9 @@ from copier import Copier, Executor, PrintingExecutor, RelativeFormatter
 from detectors import (
     CopyDetector,
     DeleteDetector,
+    OpenAPIDetector,
     OperationDetectorChain,
     PlantUMLDiagramsDetector,
-    OpenAPIDetector,
     UnnecessaryOperationsFilteringDetector,
 )
 from filesystem import Filesystem
@@ -30,6 +30,11 @@ if __name__ == "__main__":
     parser.add_argument("--branch", dest="branch", default="master")
     parser.add_argument("--author", dest="author", default="unknown author")
     parser.add_argument("--dry-run", dest="dry_run", action=argparse.BooleanOptionalAction)
+    parser.add_argument(
+        "--skip-invalid-documents",
+        dest="skip_invalid_documents",
+        action=argparse.BooleanOptionalAction,
+    )
     args = parser.parse_args()
 
     if args.command == "copy":
@@ -38,7 +43,7 @@ if __name__ == "__main__":
                 os.path.join(args.to_path, INDEX_DIRECTORY), fs, not args.dry_run
             ) as index:
                 config = ConfigLoader.default(args.from_path, args.to_path, fs).load(
-                    args.config_path
+                    args.config_path, args.skip_invalid_documents
                 )
                 Copier(
                     OperationDetectorChain(

--- a/techdocs/script/config.py
+++ b/techdocs/script/config.py
@@ -219,9 +219,7 @@ class ProjectDetailsReader:
 
     def doc_path(self, project):
         if project not in self.projects:
-            raise ProjectDoesNotExist(
-                f"Project {project} does not exist"
-            )  # FIXME - don't throw an error, just log it
+            raise ProjectDoesNotExist(f"Project {project} does not exist")
         return self.projects[project]["path"]
 
     @property


### PR DESCRIPTION
Example config:
```json
{
  "documents": [
    {
      "source": "docs/*.yaml",
      "exclude": ["paths/"],
      "destination": "analytics/",
      "project": "non-existing"
    },
    {
      "source": "docs/*.yaml",
      "exclude": ["paths/"],
      "destination": "tag-manager/",
      "project": "http-api"
    }
  ]
}
```

Current behavior
```
❯ python cli.py copy --from /tmp/copier --to /tmp/copier/destination --config config.json --index TwojeStareRepo                         
Config file load error: Project `non-existing` is not declared in target's projects.json. Offending config: {'source': 'docs/*.yaml', 'exclude': ['paths/'], 'destination': 'service/', 'project': 'non-existing'}
```

With additional flag
```
❯ python cli.py copy --from /tmp/copier --to /tmp/copier/destination --config config.json --index TwojeStareRepo --skip-invalid-documents
Warning: Project `non-existing` is not declared in target's projects.json. Offending config: {'source': 'docs/*.yaml', 'exclude': ['paths/'], 'destination': 'analytics/', 'project': 'non-existing'}
* [COPY] docs/test2.yaml -> apis/tag-manager/test2.yaml
* [COPY] docs/test.yaml -> apis/tag-manager/test.yaml


❯ python cli.py copy --from /tmp/copier --to /tmp/copier/destination --config config.json --index TwojeStareRepo --skip-invalid-documents
Warning: Project `non-existing` is not declared in target's projects.json. Offending config: {'source': 'docs/*.yaml', 'exclude': ['paths/'], 'destination': 'analytics/', 'project': 'non-existing'}
Nothing to do
```