### PR TITLE
DEVOPS-7990 Update deprecated linters

### DIFF
--- a/go/lint/.golangci.yml
+++ b/go/lint/.golangci.yml
@@ -26,12 +26,11 @@ linters:
   disable-all: true
   enable:
     - revive
-    - ifshort
     - staticcheck
+    - gosimple
     - gosec
     - dogsled
     - godox
-    - megacheck
     - govet
     - gocyclo
     - lll
@@ -43,6 +42,7 @@ linters:
     - whitespace
     - goconst
     - unconvert
+    - unused
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
```
WARN [lintersdb] The linter named "megacheck" is deprecated. It has been split into: gosimple, staticcheck, unused. 
WARN The linter 'ifshort' is deprecated (since v1.48.0) due to: The repository of the linter has been deprecated by the owner.  
ERRO [linters_context] ifshort: This linter is fully inactivated: it will not produce any reports. 
exit status 7
exit status 7

```

