### PR TITLE
ARCH-288 fix wildcard pattern handling (`*.txt` vs `**/*.txt`)

### DIFF
--- a/techdocs/script/conftest.py
+++ b/techdocs/script/conftest.py
@@ -48,4 +48,3 @@ def filesystem():
             "/tmp/bar/projects.json": json.dumps({"promil": {"path": "docs/promil"}}),
         }
     )
-

--- a/techdocs/script/detectors.py
+++ b/techdocs/script/detectors.py
@@ -90,9 +90,11 @@ class CopyDetector:
 
 class DefaultMatcher:
     def __init__(self, str_to_match):
-        self.regex = re.escape(str_to_match).replace("\\*", ".*")
+        # Escape the string and replace the wildcard with a regex wildcard
+        self.regex = re.escape(str_to_match).replace("\\*", "[^/]*")
 
     def match(self, path):
+        print(f"Path: {path}  Regex:{self.regex}")
         return re.match(self.regex, path) is not None
 
 

--- a/techdocs/script/detectors.py
+++ b/techdocs/script/detectors.py
@@ -92,12 +92,10 @@ class CopyDetector:
 
 class DefaultMatcher:
     def __init__(self, str_to_match):
-        print(str_to_match)
         # How to handle glob like **/* in the source
         self.regex = (re.escape(str_to_match).replace("\\*\\*/\\*", ".*")).replace("\\*", "[^/]*")
 
     def match(self, path):
-        print(f"Path: {path}  Regex:{self.regex}")
         return re.match(self.regex, path) is not None
 
 

--- a/techdocs/script/frontmatter.py
+++ b/techdocs/script/frontmatter.py
@@ -54,14 +54,19 @@ def last_update(author):
 def source_frontmatter_hash(source_file):
     def inner(current_content):
         return (
-            "x_source_frontmatter_hash: " + hashb(
-                source_file.split("---\n")[1].encode("utf-8")
-            ) + "\n"
-        ) if source_file.startswith("---") else ""
+            (
+                "x_source_frontmatter_hash: "
+                + hashb(source_file.split("---\n")[1].encode("utf-8"))
+                + "\n"
+            )
+            if source_file.startswith("---")
+            else ""
+        )
+
     return inner
 
 
-PATTERN = re.compile(r'.*x_source_frontmatter_hash:\s([a-z0-9]+)\n.*', re.DOTALL)
+PATTERN = re.compile(r".*x_source_frontmatter_hash:\s([a-z0-9]+)\n.*", re.DOTALL)
 
 
 def get_source_frontmatter_hash(dest_frontmatter):

--- a/techdocs/script/nodes.py
+++ b/techdocs/script/nodes.py
@@ -1,6 +1,3 @@
-import os
-
-
 # Does not check the file on disk, but uses the path to determine the type
 def looks_fileish(fspath):
     return not looks_dirish(fspath)
@@ -12,3 +9,7 @@ def looks_dirish(fspath):
 
 def looks_wildcardish(fspath):
     return "*" in fspath
+
+
+def looks_globish(fspath):
+    return "**/*" in fspath

--- a/techdocs/script/operations.py
+++ b/techdocs/script/operations.py
@@ -23,7 +23,6 @@ class GenericFileCopyOperation:
         return "copy"
 
     def execute(self, fs):
-        print(self.source_abs, self.destination_abs)
         fs.copy(self.source_abs, self.destination_abs)
 
     def has_changes(self, fs):

--- a/techdocs/script/operations.py
+++ b/techdocs/script/operations.py
@@ -23,6 +23,7 @@ class GenericFileCopyOperation:
         return "copy"
 
     def execute(self, fs):
+        print(self.source_abs, self.destination_abs)
         fs.copy(self.source_abs, self.destination_abs)
 
     def has_changes(self, fs):
@@ -280,7 +281,7 @@ class OpenAPIBundler:
                     "--ext",
                     "json",
                 ],
-                capture_output=True
+                capture_output=True,
             )
             if output.returncode != 0:
                 raise Exception(f"OpenAPI generation failed: {output.stderr.decode()}")

--- a/techdocs/script/test_copier.py
+++ b/techdocs/script/test_copier.py
@@ -33,6 +33,11 @@ def filesystem():
                             "source": "other/*.txt",
                             "destination": "somedir/",
                         },
+                        {
+                            "project": "promil",
+                            "source": "recursive/**/*.txt",
+                            "destination": "somedir/recursive/",
+                        },
                     ],
                 }
             ),
@@ -47,6 +52,9 @@ def filesystem():
             "/tmp/foo/other/due.txt": "blabla",
             "/tmp/foo/other/non-text.md": "blabla",
             "/tmp/foo/other/level/due.txt": "blabla-overwritten",
+            "/tmp/foo/recursive/due.txt": "blabla",
+            "/tmp/foo/recursive/one/due.txt": "blabla",
+            "/tmp/foo/recursive/one/two/due.txt": "blabla",
             "/tmp/bar/projects.json": json.dumps({"promil": {"path": "docs/promil"}}),
         }
     )
@@ -80,6 +88,7 @@ def test_copier(filesystem):
     assert filesystem.is_file("/tmp/bar/docs/promil/somedir/due.txt")
     assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/non-text.md")
     assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/level/due.txt")
-
-    # currently file from desired directory is overwritten by the same filename from sub directory
     assert filesystem.read_string("/tmp/bar/docs/promil/somedir/due.txt") == "blabla"
+    assert filesystem.is_file("/tmp/bar/docs/promil/somedir/recursive/due.txt")
+    assert filesystem.is_file("/tmp/bar/docs/promil/somedir/recursive/one/due.txt")
+    assert filesystem.is_file("/tmp/bar/docs/promil/somedir/recursive/one/two/due.txt")

--- a/techdocs/script/test_copier.py
+++ b/techdocs/script/test_copier.py
@@ -46,7 +46,7 @@ def filesystem():
             "/tmp/foo/other/uno.txt": "blabla",
             "/tmp/foo/other/due.txt": "blabla",
             "/tmp/foo/other/non-text.md": "blabla",
-            "/tmp/foo/other/level/due.txt": "blabla",
+            "/tmp/foo/other/level/due.txt": "blabla-overwritten",
             "/tmp/bar/projects.json": json.dumps({"promil": {"path": "docs/promil"}}),
         }
     )
@@ -80,3 +80,6 @@ def test_copier(filesystem):
     assert filesystem.is_file("/tmp/bar/docs/promil/somedir/due.txt")
     assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/non-text.md")
     assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/level/due.txt")
+
+    # currently file from desired directory is overwritten by the same filename from sub directory
+    assert filesystem.read_string("/tmp/bar/docs/promil/somedir/due.txt") == "blabla"

--- a/techdocs/script/test_copier.py
+++ b/techdocs/script/test_copier.py
@@ -55,6 +55,7 @@ def filesystem():
             "/tmp/foo/recursive/due.txt": "blabla",
             "/tmp/foo/recursive/one/due.txt": "blabla",
             "/tmp/foo/recursive/one/two/due.txt": "blabla",
+            "/tmp/foo/recursive/one/two/due.doc": "blabla",
             "/tmp/bar/projects.json": json.dumps({"promil": {"path": "docs/promil"}}),
         }
     )
@@ -92,3 +93,4 @@ def test_copier(filesystem):
     assert filesystem.is_file("/tmp/bar/docs/promil/somedir/recursive/due.txt")
     assert filesystem.is_file("/tmp/bar/docs/promil/somedir/recursive/one/due.txt")
     assert filesystem.is_file("/tmp/bar/docs/promil/somedir/recursive/one/two/due.txt")
+    assert not filesystem.is_file("/tmp/bar/docs/promil/somedir/recursive/one/two/due.doc")

--- a/techdocs/script/test_detectors.py
+++ b/techdocs/script/test_detectors.py
@@ -76,7 +76,7 @@ def test_copy():
     ),
 )
 def test_copy_create_operation_variants(
-        file, rule_source, rule_destination, expected_source, expected_destination
+    file, rule_source, rule_destination, expected_source, expected_destination
 ):
     detector = CopyDetector(
         "/home/foobar", "/tmp/Tech-docs", "Οδυσσέας Ελύτης", "master", Config([])
@@ -101,8 +101,7 @@ def test_copy_create_operation_variants(
 def test_index_load():
     fs = MockFilesystem(
         {
-            "/foo/index/Promil-platform-foo/42af564a885e1f38be3f411de2584efc3462bba68e9b5ea6dc39364b061d0a8f":
-                json.dumps(
+            "/foo/index/Promil-platform-foo/42af564a885e1f38be3f411de2584efc3462bba68e9b5ea6dc39364b061d0a8f": json.dumps(
                 {
                     "file": "heheszek",
                     "repo": "Promil-platform-foo",
@@ -145,9 +144,9 @@ def test_index_save():
             "/foo/index/Promil-platform-foo/42af564a885e1f38be3f411de2584efc3462bba68e9b5ea6dc39364b061d0a8f"
         )
     ) == {
-               "file": "heheszek",
-               "repo": "Promil-platform-foo",
-           }
+        "file": "heheszek",
+        "repo": "Promil-platform-foo",
+    }
 
 
 def test_delete():

--- a/techdocs/script/test_operations.py
+++ b/techdocs/script/test_operations.py
@@ -26,12 +26,16 @@ def test_yaml_preface_operation(filesystem):
     "source, destination, expected",
     (
         ("#foo", "#foo", True),  # lacks x_tech_docs_enriched
-        ("#foo\n", """---
+        (
+            "#foo\n",
+            """---
 foo: bar
 x_tech_docs_enriched: true
 ---
 #foo
-""", False),  # content is the same and source does not have frontmatter
+""",
+            False,
+        ),  # content is the same and source does not have frontmatter
         (
             """---
 foo: bar


### PR DESCRIPTION
This pr fixes a bug due to specifying `*.txt` with a destination like `/foo` will copy all .txt files from the entire source to foo, flattening the directory structure.

So files like:
```
text.txt
dir/text2.txt
another-dir/and-another/text3.txt
```
improperly becomes 
```
foo/text.txt
foo/text2.txt
foo/text3.txt
```

**Now this case is fixed and will only copy top level `foo/text.txt` according to the pattern.** 

This pr also adds support for glob pattern `**/*` which will now copy recursively directories and files if set. 

So having `**/*.txt`:
```
text.txt
dir/text2.txt
another-dir/and-another/text3.txt
```
Will create such structure:
```
foo/text.txt
foo/dir/text2.txt
foo/another-dir/and-another/text3.txt
```

