### PR TITLE
Add OpenAPIValidator for catching openapi errors

### DIFF
--- a/.github/workflows/push_docs.yaml
+++ b/.github/workflows/push_docs.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run Copy Script in Dry Run Mode
         id: dry-run
-        uses: PiwikPRO/actions/techdocs@master
+        uses: PiwikPRO/actions/techdocs@feature/ARCH-511-rdme-validator
         if: ${{ github.ref_name == env.MAIN_BRANCH || env.BRANCH_EXISTS == 'true' }}
         with:
           from: .
@@ -127,7 +127,7 @@ jobs:
           echo "CHANGES=1" >> $GITHUB_ENV
 
       - name: Run Copy Script
-        uses: PiwikPRO/actions/techdocs@master
+        uses: PiwikPRO/actions/techdocs@feature/ARCH-511-rdme-validator
         id: copy
         if: env.CHANGES != '0'
         with:

--- a/.github/workflows/push_docs.yaml
+++ b/.github/workflows/push_docs.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run Copy Script in Dry Run Mode
         id: dry-run
-        uses: PiwikPRO/actions/techdocs@feature/ARCH-511-rdme-validator
+        uses: PiwikPRO/actions/techdocs@master
         if: ${{ github.ref_name == env.MAIN_BRANCH || env.BRANCH_EXISTS == 'true' }}
         with:
           from: .
@@ -127,7 +127,7 @@ jobs:
           echo "CHANGES=1" >> $GITHUB_ENV
 
       - name: Run Copy Script
-        uses: PiwikPRO/actions/techdocs@feature/ARCH-511-rdme-validator
+        uses: PiwikPRO/actions/techdocs@master
         id: copy
         if: env.CHANGES != '0'
         with:

--- a/techdocs/script/detectors.py
+++ b/techdocs/script/detectors.py
@@ -12,7 +12,7 @@ from operations import (
     DeleteOperation,
     DockerPlantUMLGenerator,
     GenericFileCopyOperation,
-    PlantUMLDiagramRenderOperation,
+    OpenAPIValidator, PlantUMLDiagramRenderOperation,
     YAMLPrefaceEnrichingCopyOperation,
 )
 from operations import OpenAPIBundler, OpenAPIOperation
@@ -20,7 +20,7 @@ from operations import OpenAPIBundler, OpenAPIOperation
 
 class CopyDetector:
     def __init__(
-        self, from_path: str, to_path: str, author: str, branch: str, config: Config
+            self, from_path: str, to_path: str, author: str, branch: str, config: Config
     ) -> None:
         self.copy_rules = [
             Rule(
@@ -60,7 +60,7 @@ class CopyDetector:
                 path.join(rule.config.destination, destination_file),
             )
         elif nodes.looks_fileish(rule.config.source) and nodes.looks_fileish(
-            rule.config.destination
+                rule.config.destination
         ):
             relative_src, relative_dst = (
                 file,
@@ -69,7 +69,7 @@ class CopyDetector:
         elif nodes.looks_dirish(rule.config.source) and nodes.looks_dirish(rule.config.destination):
             relative_src, relative_dst = (
                 file,
-                path.join(rule.config.destination, file[len(rule.config.source) - 1 :]),
+                path.join(rule.config.destination, file[len(rule.config.source) - 1:]),
             )
         else:
             return None
@@ -190,8 +190,9 @@ class OperationDetectorChain:
 
 
 class OpenAPIDetector:
-    def __init__(self, bundler=None):
+    def __init__(self, bundler=None, validator=None):
         self.bundler = bundler or OpenAPIBundler()
+        self.validator = validator or OpenAPIValidator()
 
     def _detect_yaml_files(self, fs, previous_operations):
         yaml_files = list(

--- a/techdocs/script/detectors.py
+++ b/techdocs/script/detectors.py
@@ -251,6 +251,7 @@ class OpenAPIDetector:
                 openapi_spec.source_abs,
                 openapi_spec.destination_abs,
                 self.bundler,
+                self.validator,
             )
             for openapi_spec in openapi_spec_files
         ]

--- a/techdocs/script/operations.py
+++ b/techdocs/script/operations.py
@@ -296,7 +296,7 @@ class OpenAPIBundler:
 
 
 class OpenAPIValidator:
-    RDME_VERSION = "8.6.2"
+    RDME_VERSION = "latest"
 
     def validate(self, source_abs):
         output = subprocess.run(


### PR DESCRIPTION
This is the first iteration of common validator for openapi specification. It's very simple right now yet it can catch some inconsistencies in specification like parameter mismatch or some leftover spec. 

Check related task comments for some examples.