### PR TITLE
ARCH-630 remove semver restriction while signing image from git tag

### DIFF
--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -88,14 +88,7 @@ runs:
           echo "::set-output name=should_sign::false"
           exit 0
         fi
-        
-        TAG_NAME="${{ inputs.destination-tag }}"
-        SEMVER_REGEX="^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$"
-        if [[ "$TAG_NAME" =~ $SEMVER_REGEX ]]; then
-          echo "::set-output name=should_sign::true"
-        else
-          echo "::set-output name=should_sign::false"
-        fi    
+        echo "::set-output name=should_sign::true"
 
     - name: Download image signing toolkit (cosign)
       if: ${{ steps.sign_check.outputs.should_sign == 'true' }}


### PR DESCRIPTION
As discussed in this [slack thread](https://piwikpro.slack.com/archives/C01C0M9F1KQ/p1739206709185989)  - current semver restriction did cause some confusion.

After discussing with Security SIG we decided to remove this restriction entirely. From now on every git tag will be signed no matter what. 