### PR TITLE
cosign download retry mechanism

### DIFF
--- a/cosign/download/action.yaml
+++ b/cosign/download/action.yaml
@@ -17,7 +17,7 @@ runs:
     - name: "Download binary"
       shell: bash
       run: |
-        API_URL="https://api.github.com/repos/sigstore/cosign/releasses/${{ inputs.version }}"
+        API_URL="https://api.github.com/repos/sigstore/cosign/releases/${{ inputs.version }}"
         MAX_ATTEMPTS=${{ inputs.max_attempts }}
         ASSET_NAME="cosign-linux-amd64"
         TEMP_FILE="/tmp/cosign_release.json"

--- a/cosign/download/action.yaml
+++ b/cosign/download/action.yaml
@@ -5,16 +5,75 @@ inputs:
     required: false
     description: "Specific release id, selected from https://github.com/sigstore/cosign/releases"
     # Find ID by tag:
-    # curl https://api.github.com/repos/sigstore/cosign/releases | jq '.[] | select(.tag_name == "v2.2.0").id'
-    default: "139369855" # v2.2.3
+    # curl https://api.github.com/repos/sigstore/cosign/releases | jq '.[] | select(.tag_name == "v2.5.3").id'
+    default: "233309868" # v2.5.3
+  max_attempts:
+    required: false
+    description: "Maximum number of download attempts before giving up"
+    default: "3"
 runs:
   using: "composite"
   steps:
     - name: "Download binary"
       shell: bash
       run: |
-        URL=`curl -s https://api.github.com/repos/sigstore/cosign/releases/${{ inputs.version }} | jq -r '.assets[] | select(.name=="cosign-linux-amd64") | .browser_download_url'`;
-        wget -q $URL --output-document cosign;
-        chmod +x cosign;
-        mkdir -p $HOME/.local/bin;
-        mv cosign $HOME/.local/bin;
+        API_URL="https://api.github.com/repos/sigstore/cosign/releases/${{ inputs.version }}"
+        MAX_ATTEMPTS=${{ inputs.max_attempts }}
+        ASSET_NAME="cosign-linux-amd64"
+        TEMP_FILE="/tmp/cosign_release.json"
+        BINARY_NAME="cosign"
+        INSTALL_DIR="$HOME/.local/bin"
+        
+        ATTEMPT=1
+        
+        echo "Downloading cosign binary for release ${{ inputs.version }}"
+        
+        while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+          echo "Attempt $ATTEMPT of $MAX_ATTEMPTS"
+          
+          HTTP_STATUS=$(curl -w "%{http_code}" -s -o "$TEMP_FILE" "$API_URL")
+          
+          if [ "$HTTP_STATUS" -eq 200 ]; then
+            if jq -e ".assets[]? | select(.name==\"$ASSET_NAME\") | .browser_download_url" "$TEMP_FILE" > /dev/null 2>&1; then
+              URL=$(jq -r ".assets[] | select(.name==\"$ASSET_NAME\") | .browser_download_url" "$TEMP_FILE")
+              
+              if [ -n "$URL" ] && [ "$URL" != "null" ]; then
+                echo "Found download URL: $URL"
+                
+                if wget -q "$URL" --output-document "$BINARY_NAME"; then
+                  chmod +x "$BINARY_NAME"
+                  mkdir -p "$INSTALL_DIR"
+                  mv "$BINARY_NAME" "$INSTALL_DIR"
+                  echo "Cosign binary successfully downloaded and installed to $INSTALL_DIR"
+                  rm -f "$TEMP_FILE"
+                  exit 0
+                else
+                  echo "::error title=Download Failed::Failed to download cosign binary from $URL"
+                fi
+              else
+                echo "::error title=Invalid Response::Empty or null download URL extracted from GitHub API"
+                echo "API Response:"
+                cat "$TEMP_FILE"
+              fi
+            else
+              echo "::error title=Asset Not Found::Release ${{ inputs.version }} doesn't contain expected $ASSET_NAME asset"
+              echo "API Response:"
+              cat "$TEMP_FILE"
+            fi
+          else
+            echo "::error title=GitHub API Error::API request failed with HTTP status $HTTP_STATUS"
+            echo "API Response:"
+            cat "$TEMP_FILE" 2>/dev/null || echo "No response body available"
+          fi
+          
+          if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+            SLEEP_TIME=$((ATTEMPT * 2))
+            echo "::warning title=Retry Attempt::Download attempt $ATTEMPT failed, retrying in ${SLEEP_TIME} seconds..."
+            sleep $SLEEP_TIME
+          fi
+          
+          ATTEMPT=$((ATTEMPT + 1))
+        done
+        
+        echo "::error title=Maximum Attempts Exceeded::Failed to download cosign binary after $MAX_ATTEMPTS attempts"
+        exit 1

--- a/cosign/download/action.yaml
+++ b/cosign/download/action.yaml
@@ -36,26 +36,21 @@ runs:
           CURL_EXIT_CODE=$?
           
           if [ $CURL_EXIT_CODE -eq 0 ] && [ -n "$HTTP_STATUS" ] && [ "$HTTP_STATUS" -eq 200 ]; then
-            if jq -e ".assets[]? | select(.name==\"$ASSET_NAME\") | .browser_download_url" "$TEMP_FILE" > /dev/null 2>&1; then
-              URL=$(jq -r ".assets[] | select(.name==\"$ASSET_NAME\") | .browser_download_url" "$TEMP_FILE")
+            # Extract download URL with single jq execution
+            URL=$(jq -r ".assets[]? | select(.name==\"$ASSET_NAME\") | .browser_download_url" "$TEMP_FILE" 2>/dev/null)
+            
+            if [ -n "$URL" ] && [ "$URL" != "null" ]; then
+              echo "Found download URL: $URL"
               
-              if [ -n "$URL" ] && [ "$URL" != "null" ]; then
-                echo "Found download URL: $URL"
-                
-                if wget -q "$URL" --output-document "$BINARY_NAME"; then
-                  chmod +x "$BINARY_NAME"
-                  mkdir -p "$INSTALL_DIR"
-                  mv "$BINARY_NAME" "$INSTALL_DIR"
-                  echo "Cosign binary successfully downloaded and installed to $INSTALL_DIR"
-                  rm -f "$TEMP_FILE"
-                  exit 0
-                else
-                  echo "::error title=Download Failed::Failed to download cosign binary from $URL"
-                fi
+              if wget -q "$URL" --output-document "$BINARY_NAME"; then
+                chmod +x "$BINARY_NAME"
+                mkdir -p "$INSTALL_DIR"
+                mv "$BINARY_NAME" "$INSTALL_DIR"
+                echo "Cosign binary successfully downloaded and installed to $INSTALL_DIR"
+                rm -f "$TEMP_FILE"
+                exit 0
               else
-                echo "::error title=Invalid Response::Empty or null download URL extracted from GitHub API"
-                echo "API Response:"
-                cat "$TEMP_FILE"
+                echo "::error title=Download Failed::Failed to download cosign binary from $URL"
               fi
             else
               echo "::error title=Asset Not Found::Release ${{ inputs.version }} doesn't contain expected $ASSET_NAME asset"

--- a/cosign/download/action.yaml
+++ b/cosign/download/action.yaml
@@ -17,7 +17,7 @@ runs:
     - name: "Download binary"
       shell: bash
       run: |
-        API_URL="https://api.github.com/repos/sigstore/cosign/releases/${{ inputs.version }}"
+        API_URL="https://api.github.com/repos/sigstore/cosign/releasses/${{ inputs.version }}"
         MAX_ATTEMPTS=${{ inputs.max_attempts }}
         ASSET_NAME="cosign-linux-amd64"
         TEMP_FILE="/tmp/cosign_release.json"

--- a/cosign/download/action.yaml
+++ b/cosign/download/action.yaml
@@ -31,9 +31,11 @@ runs:
         while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
           echo "Attempt $ATTEMPT of $MAX_ATTEMPTS"
           
-          HTTP_STATUS=$(curl -w "%{http_code}" -s -o "$TEMP_FILE" "$API_URL")
+          # Fetch API response with error handling
+          HTTP_STATUS=$(curl -w "%{http_code}" -s -o "$TEMP_FILE" "$API_URL" 2>/dev/null)
+          CURL_EXIT_CODE=$?
           
-          if [ "$HTTP_STATUS" -eq 200 ]; then
+          if [ $CURL_EXIT_CODE -eq 0 ] && [ -n "$HTTP_STATUS" ] && [ "$HTTP_STATUS" -eq 200 ]; then
             if jq -e ".assets[]? | select(.name==\"$ASSET_NAME\") | .browser_download_url" "$TEMP_FILE" > /dev/null 2>&1; then
               URL=$(jq -r ".assets[] | select(.name==\"$ASSET_NAME\") | .browser_download_url" "$TEMP_FILE")
               
@@ -61,9 +63,13 @@ runs:
               cat "$TEMP_FILE"
             fi
           else
-            echo "::error title=GitHub API Error::API request failed with HTTP status $HTTP_STATUS"
-            echo "API Response:"
-            cat "$TEMP_FILE" 2>/dev/null || echo "No response body available"
+            if [ $CURL_EXIT_CODE -ne 0 ]; then
+              echo "::error title=Network Error::Failed to connect to GitHub API (curl exit code: $CURL_EXIT_CODE)"
+            else
+              echo "::error title=GitHub API Error::API request failed with HTTP status $HTTP_STATUS"
+              echo "API Response:"
+              cat "$TEMP_FILE" 2>/dev/null || echo "No response body available"
+            fi
           fi
           
           if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -94,7 +94,7 @@ runs:
 
     - name: Download image signing toolkit (cosign)
       if: ${{ steps.sign_check.outputs.should_sign == 'true' }}
-      uses: PiwikPRO/actions/cosign/download@85b53606f434c343f5b885839b188a7376d38d12
+      uses: PiwikPRO/actions/cosign/download@da68a14b17cbfd388838c51ecc5322aa3815046d
 
     - name: Sign production docker image
       if: ${{ steps.sign_check.outputs.should_sign == 'true' }}

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -94,7 +94,7 @@ runs:
 
     - name: Download image signing toolkit (cosign)
       if: ${{ steps.sign_check.outputs.should_sign == 'true' }}
-      uses: PiwikPRO/actions/cosign/download@85b53606f434c343f5b885839b188a7376d38d12
+      uses: PiwikPRO/actions/cosign/download@master
 
     - name: Sign production docker image
       if: ${{ steps.sign_check.outputs.should_sign == 'true' }}

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -94,7 +94,7 @@ runs:
 
     - name: Download image signing toolkit (cosign)
       if: ${{ steps.sign_check.outputs.should_sign == 'true' }}
-      uses: PiwikPRO/actions/cosign/download@bugfix/ARCH-711-handle-invalid-cosign-download-responses
+      uses: PiwikPRO/actions/cosign/download@85b53606f434c343f5b885839b188a7376d38d12
 
     - name: Sign production docker image
       if: ${{ steps.sign_check.outputs.should_sign == 'true' }}

--- a/godtools/push/action.yaml
+++ b/godtools/push/action.yaml
@@ -94,7 +94,7 @@ runs:
 
     - name: Download image signing toolkit (cosign)
       if: ${{ steps.sign_check.outputs.should_sign == 'true' }}
-      uses: PiwikPRO/actions/cosign/download@da68a14b17cbfd388838c51ecc5322aa3815046d
+      uses: PiwikPRO/actions/cosign/download@bugfix/ARCH-711-handle-invalid-cosign-download-responses
 
     - name: Sign production docker image
       if: ${{ steps.sign_check.outputs.should_sign == 'true' }}


### PR DESCRIPTION
Due to occasional hiccups while downloading cosign and unclear jq error behind it:
- Added retry mechanism for downloading cosign binary
- More clear error reporting 
- Bumped cosign binary to latest version `v2.5.3` 

Test run: https://github.com/PiwikPRO/kong/actions/runs/16565977888 
Controlled failed run: https://github.com/PiwikPRO/kong/actions/runs/16566152871

More details in the related task.