### PR TITLE
Remove obsolete unfor19/install-aws-cli-action from actions

### DIFF
--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -29,8 +29,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - uses: unfor19/install-aws-cli-action@f2649938c0ed0514cfc5448f0b96516580d34e53
-
     - name: Update current branch coverage (pull_request)
       if: ${{ github.event_name == 'pull_request' }}
       shell: bash

--- a/inclint/action.yml
+++ b/inclint/action.yml
@@ -30,8 +30,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - uses: unfor19/install-aws-cli-action@v1
-
     - name: Update current branch linter-errors (pull_request)
       if: ${{ github.event_name == 'pull_request' }}
       shell: bash

--- a/s3/upload/action.yaml
+++ b/s3/upload/action.yaml
@@ -35,8 +35,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: unfor19/install-aws-cli-action@v1
-
     - name: Generate index.html if it doesn't exist
       if: ${{ inputs.echo-destination-index-html == 'true' }}
       shell: bash


### PR DESCRIPTION
Removing obsolete action for installing aws-cli since it's already present on runner images.

Source: 
- https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#cli-tools
- https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#cli-tools