### PR TITLE
added pr title conventional commits lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
       - [Update changelog](#update-changelog)
     - [Developers Portal](#developers-portal)
     - [Changelog](#changelog)
+    - [PR title](#pr-title)
     - [Using aws-cli with proxy](#using-aws-cli-with-proxy)
     - [Godtools](#godtools)
       - [Setup](#setup)
@@ -131,6 +132,47 @@ jobs:
         uses: PiwikPRO/actions/changelog/update@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### PR title
+
+Validates a pull request title against the [Conventional Commits](https://www.conventionalcommits.org/) format.
+
+A title is accepted when it matches `type(scope)?!?: subject`, where:
+- `type` is on the allowed list (`types` input)
+- `scope` is optional, and by default may be anything
+- `!` after the type or scope marks a breaking change
+- `subject` starts with a lowercase letter and does not end with a period
+
+Inputs:
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `types` | `feat\|fix\|perf\|refactor\|docs\|test\|build\|ci\|chore\|revert` | Pipe-separated list of allowed types. |
+| `scopes` | `*` | Pipe-separated list of allowed scopes. The default `*` accepts any scope. Set it only if you want to restrict scopes to a fixed list, e.g. `release\|changelog\|deps`. |
+
+Example usage:
+```
+name: Lint PR Title
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: PiwikPRO/actions/pr-title@master
 ```
 
 ### Using aws-cli with proxy

--- a/pr-title/action.yaml
+++ b/pr-title/action.yaml
@@ -1,0 +1,21 @@
+name: Lint PR title
+description: Validate a pull request title against the Conventional Commits format
+inputs:
+  types:
+    required: false
+    description: Pipe-separated list of allowed commit types
+    default: feat|fix|perf|refactor|docs|test|build|ci|chore|revert
+  scopes:
+    required: false
+    description: Pipe-separated list of allowed scopes, or "*" to allow any scope
+    default: '*'
+runs:
+  using: composite
+  steps:
+    - name: Lint PR title
+      shell: bash
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        TYPES: ${{ inputs.types }}
+        SCOPES: ${{ inputs.scopes }}
+      run: ${{ github.action_path }}/lint.sh

--- a/pr-title/lint.sh
+++ b/pr-title/lint.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Validate a pull request title against the Conventional Commits format.
+# Configuration is passed by action.yaml as environment variables:
+#   PR_TITLE - the title to validate
+#   TYPES    - pipe-separated list of allowed types
+#   SCOPES   - pipe-separated list of allowed scopes, or "*" for any
+set -euo pipefail
+
+title="${PR_TITLE:-}"
+types="${TYPES:?TYPES must be set}"
+scopes="${SCOPES:-*}"
+
+if [ "$scopes" = '*' ]; then
+  scope='[^()]+'
+  scopes_help='any scope'
+else
+  scope="$scopes"
+  scopes_help="$scopes"
+fi
+
+pattern="^($types)(\(($scope)\))?!?: (?![A-Z]).*[^.]$"
+
+help_text() {
+  cat <<EOF
+The PR title must follow the Conventional Commits format:
+
+    type(scope)?!?: subject
+
+Allowed types:   $types
+Allowed scopes:  $scopes_help   (optional)
+Rules:
+  - subject must start with a lowercase letter
+  - subject must not end with a period
+  - "!" after type/scope marks a breaking change
+
+Examples:
+  feat: add cross-domain tracking helper
+  fix(deps): bump tracking-base-library to 1.7.0
+  refactor!: drop deprecated initialize signature
+EOF
+}
+
+if [ -z "$title" ]; then
+  echo "::error title=Empty PR title::There is no pull request title to read. This action only works on pull_request events."
+  exit 1
+fi
+
+if grep -qP "$pattern" <<<"$title"; then
+  echo "PR title OK: $title"
+  exit 0
+fi
+
+echo "::error title=Invalid PR title::\"$title\" is not a valid Conventional Commit title"
+help_text
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Invalid PR title"
+    echo
+    echo "\`$title\` is not a valid Conventional Commit title."
+    echo
+    echo '```'
+    help_text
+    echo '```'
+  } >>"$GITHUB_STEP_SUMMARY"
+fi
+
+exit 1


### PR DESCRIPTION
To unify git commit history in integrations SDK's we want to introduce a github action that will lint the PR title according to the conventional commits standard - https://www.conventionalcommits.org/en/v1.0.0/#summary. 