### PR TITLE
Simplify version-update action (trigger update for every tag, even hotfixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ Main idea is to automate bumping explicit tmp images in stack repo to allow test
 
 For **dev branch commits**: When a commit is pushed to the configured development branch and the image build succeeds, it generates a version string like `tmp-cf3ebd52` and triggers the `update-service-version.yaml` workflow in the target repository.
 
-For **tags**: When a tag is created, it extracts the tag name (e.g., `1.32.4`) and checks if the tagged commit exists in the configured development branch using `git merge-base --is-ancestor`. If the commit exists in that branch, it triggers the workflow with the tag name as version. If not, it skips triggering (assumes a hotfix released from `master` that has not been merged back yet).
+For **tags**: When any tag is created, including a hotfix tag, it triggers the workflow with the tag name (e.g., `1.32.4`) as the version.
 
 #### Usage
 
@@ -840,13 +840,12 @@ jobs:
         uses: PiwikPRO/actions/version-update/trigger@master
         with:
           service-name: name-of-the-app
-          dev-branch: ${{ github.event.repository.default_branch }}
           target-repo: Promil-stack-analytics
           target-workflow-ref: develop
           workflow-token: ${{ steps.app-token.outputs.token }}
 ```
 
-Place the action after the step that builds and pushes the image. This way version updates are only triggered after a successful image build, and skipped workflows do not need any extra handling inside the action. In the calling workflow, gate the step so it only runs for the development branch and for tags.
+Place the action after the step that builds and pushes the image so version updates are only triggered after a successful image build. In the calling workflow, gate the step so it only runs for the development branch and for tags. Every tag is dispatched, including hotfix tags.
 
 #### Inputs
 
@@ -855,7 +854,6 @@ Place the action after the step that builds and pushes the image. This way versi
 | `service-name` | Name of the service to update (e.g., etl, reporting, ui) | Yes | -         |
 | `target-repo` | Target repository to trigger workflow in | Yes | -         |
 | `workflow-token` | GitHub token with workflow dispatch permissions (fine-grained PAT with "Actions: Read and write") | Yes | -         |
-| `dev-branch` | Name of the development branch to validate tags against | No | `develop` |
 | `target-workflow-ref` | Git ref to use when triggering the target workflow | No | `develop` |
 
 #### Requirements

--- a/version-update/trigger/action.yaml
+++ b/version-update/trigger/action.yaml
@@ -1,13 +1,9 @@
 name: Trigger version update
-description: Triggers version update workflow in a target repository based on dev branch commits or tags
+description: Triggers version update workflow in a target repository for development commits and tags
 inputs:
   service-name:
     description: "Name of the service to update (e.g. etl, reporting, ui, administrationUI)"
     required: true
-  dev-branch:
-    description: "Name of the development branch to validate tags against"
-    required: false
-    default: "develop"
   target-repo:
     description: "Target repository to trigger workflow in (e.g. Promil-stack-analytics)"
     required: true
@@ -21,45 +17,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0  # Fetch all history for all branches and tags
-
-    - name: Determine version and validate tag
-      id: version
-      shell: bash
-      run: |
-        if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-          # Extract tag name
-          TAG="${GITHUB_REF#refs/tags/}"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          
-          # Check if this tag's commit exists in dev branch
-          if git merge-base --is-ancestor "${{ github.sha }}" origin/${{ inputs.dev-branch }}; then
-            echo "✅ Tag $TAG points to a commit that exists in ${{ inputs.dev-branch }} branch"
-            echo "version=$TAG" >> $GITHUB_OUTPUT
-            echo "should_trigger=true" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️ Tag $TAG does not exist in ${{ inputs.dev-branch }} branch (likely a hotfix tag from master)"
-            echo "Skipping version update trigger"
-            echo "should_trigger=false" >> $GITHUB_OUTPUT
-          fi
-        else
-          # This is a push to the development branch.
-          SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
-          echo "version=tmp-$SHA" >> $GITHUB_OUTPUT
-          echo "should_trigger=true" >> $GITHUB_OUTPUT
-          echo "Version will be: tmp-$SHA"
-        fi
-
     - name: Trigger workflow_dispatch in target repository
-      if: steps.version.outputs.should_trigger == 'true'
       uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.workflow-token }}
         script: |
+          const version = context.ref.startsWith('refs/tags/')
+            ? context.ref.replace('refs/tags/', '')
+            : `tmp-${context.sha.slice(0, 7)}`;
+
           await github.rest.actions.createWorkflowDispatch({
             owner: context.repo.owner,
             repo: '${{ inputs.target-repo }}',
@@ -67,34 +33,22 @@ runs:
             ref: '${{ inputs.target-workflow-ref }}',
             inputs: {
               service_name: '${{ inputs.service-name }}',
-              version: '${{ steps.version.outputs.version }}',
+              version,
             }
           });
-          console.log('✅ Workflow dispatch triggered successfully');
-          console.log('Service: ${{ inputs.service-name }}');
-          console.log('Version: ${{ steps.version.outputs.version }}');
-          console.log('Target repo: ${{ inputs.target-repo }}');
-          console.log('Triggered by: ${{ github.actor }}');
+          console.log(`Triggered version update for ${{ inputs.service-name }} to ${version}`);
 
-    - name: Summary
-      if: steps.version.outputs.should_trigger == 'true'
-      shell: bash
-      run: |
-        echo "### Version Update Triggered" >> $GITHUB_STEP_SUMMARY
-        echo "- Service: **${{ inputs.service-name }}**" >> $GITHUB_STEP_SUMMARY
-        echo "- Version: **${{ steps.version.outputs.version }}**" >> $GITHUB_STEP_SUMMARY
-        echo "- Target: ${{ inputs.target-repo }}" >> $GITHUB_STEP_SUMMARY
-        echo "- Triggered by: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
-        echo "- Source commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "[View workflow runs in target repo →](https://github.com/${{ github.repository_owner }}/${{ inputs.target-repo }}/actions/workflows/update-service-version.yaml)" >> $GITHUB_STEP_SUMMARY
-
-    - name: Skipped Summary
-      if: steps.version.outputs.should_trigger == 'false'
-      shell: bash
-      run: |
-        echo "### Version Update Skipped" >> $GITHUB_STEP_SUMMARY
-        echo "⚠️ Tag **${{ steps.version.outputs.tag }}** does not exist in ${{ inputs.dev-branch }} branch" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "This is likely a hotfix tag released directly from master." >> $GITHUB_STEP_SUMMARY
-        echo "Version updates are only triggered for tags that exist in the ${{ inputs.dev-branch }} branch." >> $GITHUB_STEP_SUMMARY
+          await core.summary
+            .addHeading('Version Update Triggered', 3)
+            .addList([
+              `Service: ${{ inputs.service-name }}`,
+              `Version: ${version}`,
+              `Target: ${{ inputs.target-repo }}`,
+              `Triggered by: ${context.actor}`,
+              `Source commit: ${context.sha}`,
+            ])
+            .addLink(
+              'View workflow runs in target repo',
+              `https://github.com/${context.repo.owner}/${{ inputs.target-repo }}/actions/workflows/update-service-version.yaml`,
+            )
+            .write();


### PR DESCRIPTION
that fancy-schmancy "hotfix" detection haven't even work..
I fixed it, but didn't push, because I realized that it's not worth over-complicating the flow - theoretically bumping on every tag shouldn't be a problem, because version bump would be triggered by:

1. regular commits to `develop` branch :heavy_check_mark: 
2. regular release tags :heavy_check_mark: 
3. hotfix release tags (from master/previous tag), which in normal flow should be followed by `master` -> `develop` merge, so final version in stack would point to dev again :heavy_check_mark:

btw removal of `dev-branch` isn't a breaking change - github ignores that input, so "client" repos can migrate in own pace