### PR TITLE
Allow commit titles generated by github automations

### DIFF
--- a/gitlint/.gitlint
+++ b/gitlint/.gitlint
@@ -2,7 +2,7 @@
 ignore=T2,T3,T4,T5,T6,T8,B1,B2,B3,B4,B5,B6,B7,B8,M1
 
 [title-match-regex]
-regex=^(((bugfix|feature)/)?[A-Z]+-[0-9]+)|Squashed|Merge\s
+regex=^(?:((?:bugfix|feature)/)?[A-Z]+-[0-9]+|Squashed|Merge)\s
 
 [title-max-length]
 line-length=120

--- a/gitlint/.gitlint
+++ b/gitlint/.gitlint
@@ -2,7 +2,7 @@
 ignore=T2,T3,T4,T5,T6,T8,B1,B2,B3,B4,B5,B6,B7,B8,M1
 
 [title-match-regex]
-regex=^((bugfix|feature)/)?[A-Z]+-[0-9]+\s
+regex=^(((bugfix|feature)/)?[A-Z]+-[0-9]+)|Squashed|Merge\s
 
 [title-max-length]
 line-length=120


### PR DESCRIPTION
Rule should allow commits made by github (e.g. during merges and squashes). This is especially useful when doing subtree pulls.